### PR TITLE
Make all navigation elements more responsive

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -169,24 +169,3 @@ body {
     top: -15px;
     right: -15px;
 }
-
-.card-img {
-    width: 100%;
-    height: 10vw;
-    object-fit: cover;
-}
-
-.nav > a.nav-link {
-    color: rgba(0,0,0,.5);
-}
-
-.nav > a.nav-link:hover,
-.nav > a.nav-link:focus {
-    color: rgba(0,0,0,.7);
-}
-
-.nav > a.nav-link.active,
-.nav > a.nav-link.active:hover,
-.nav > a.nav-link.active:focus {
-    color: rgba(0,0,0,.9);
-}

--- a/resources/views/includes/nav.blade.php
+++ b/resources/views/includes/nav.blade.php
@@ -68,9 +68,10 @@
             @else
             <li class="nav-item dropdown">
                 <a class="nav-link mr-2" href="#" id="notificationDropdown" data-toggle="dropdown">
-                    <i class="fas fa-bell notification-bell"></i>
+                    <i class="fas fa-bell notification-bell mr-lg-2"></i>
                     <span class="badge badge-notify" id="notify-count">
                     </span>
+                    <span class="d-lg-none">Notifications</span>
                 </a>
 
                 <div class="dropdown-menu keep-open dropdown-menu-right" aria-labelledby="notificationDropdown"

--- a/resources/views/includes/sidebar.blade.php
+++ b/resources/views/includes/sidebar.blade.php
@@ -1,6 +1,6 @@
-<div id="sidebar-container" class="sidebar-expanded d-none d-lg-block col-2">
+<div id="sidebar-container" class="sidebar-expanded d-none d-lg-block col-lg-2">
     <!-- hidden on <=md -->
-    <ul class="list-group sticky-top sticky-offset">
+    <div class="list-group sticky-top sticky-offset">
         <li class="list-group-item sidebar-separator-title text-muted d-flex align-items-center menu-collapsed">
             <small class="text-uppercase">Flights</small>
         </li>
@@ -72,7 +72,7 @@
         data-target="#helpModal">
             <div class="d-flex w-100 justify-content-start align-items-center">
                 <i class="fa fa-question-circle fa-fw mr-3"></i>
-                <span class="menu-collapsed">Help</span>
+                    Help
             </div>
         </a>
 
@@ -100,5 +100,57 @@
                 </a>
             </div>
         -->
-    </ul>
+    </div>
 </div>
+
+<nav id="pills-container" class="nav nav-pills nav-fill d-lg-none px-3 pt-3">
+    <a
+    href="{{ route('flights.index') }}"
+    class="nav-item nav-link
+    @if(Route::currentRouteName() === 'flights.index')) active @endif">
+        <i class="fas fa-fw mr-2 fa-search"></i>Find Flights
+    </a>
+
+    <a
+    href="{{ route('flights.user-flights') }}"
+    class="nav-item nav-link
+    @if(strpos(Route::currentRouteName(), 'flights') !== false && Route::currentRouteName() !== 'flights.index') active @endif">
+        <i class="fas fa-fw mr-2 fa-plane"></i>My Flights
+    </a>
+
+    <a
+    href="{{ route('dispatch.index') }}"
+    class="nav-item nav-link
+    @if(strpos(Route::currentRouteName(), 'dispatch') !== false) active @endif">
+        <i class="fas fa-fw mr-2 fa-file-contract"></i>Dispatch
+    </a>
+
+    <a href="#" class="nav-item nav-link disabled">
+        <i class="fa fa-id-card fa-fw mr-3"></i>Profile
+    </a>
+
+    <a
+    href="{{ route('account.index') }}"
+    class="nav-item nav-link
+    @if(strpos(Route::currentRouteName(), 'account') !== false && !(strpos(Route::currentRouteName(), 'account.admin') !== false)) active @endif">
+        <i class="fa fa-user-cog fa-fw mr-3"></i>Account
+    </a>
+
+    @role('admin')
+        <a
+        href="{{ route('admin.users.index') }}"
+        class="nav-item nav-link
+        @if(strpos(Route::currentRouteName(), 'admin') !== false) active @endif">
+            <i class="fa fa-user-shield fa-fw mr-3"></i>Admin
+        </a>
+    @endrole
+
+    <a
+    href="#"
+    class="nav-item nav-link"
+    data-toggle="modal"
+    data-target="#helpModal">
+        <i class="fa fa-question-circle fa-fw mr-3"></i>Help
+    </a>
+
+</nav>

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -32,7 +32,7 @@
                     @unless(strpos(Route::currentRouteName(), 'blog') !== false)
                         @include('includes.sidebar')
                     @endunless
-                    <div class="col p-4" id="content-div">
+                    <div class="col-lg-10 p-4" id="content-div">
                         <div class="notify-toast-parent" aria-live="polite" aria-atomic="true">
                             <div class="notify-toast-position" id="notification-div"></div>
                         </div>


### PR DESCRIPTION
Fixed issue where sidebar would not correctly hide on narrow viewports, and added nav pills on narrow viewports (below bootstrap `lg`).

Also improved behaviour of top navbar when collapsed.